### PR TITLE
Add basic GitHub workflows

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -27,9 +27,6 @@ jobs:
         with:
           go-version: '1.22.1'
 
-      - name: Create bin directory
-        run: mkdir -p ./bin
-
       - name: Build embed_code.go for Windows
         if: matrix.os == 'windows-latest'
         run: go build -o ./bin/embed-code-win.exe -trimpath ./main.go

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -46,6 +46,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: './bin'
-          message: 'Build embed_code.go for ${{ matrix.os }}'
+          message: 'Add binary for ${{ matrix.os }}.'
           default_author: github_actions
           push: true

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -1,0 +1,54 @@
+name: Build and Commit Binaries
+
+on: push
+
+concurrency:
+  group: building
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    # Prevents the workflow from running on non-human triggers.
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      max-parallel: 1
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Up Go Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.1'
+
+      - name: Create bin directory
+        run: mkdir -p ./bin
+
+      - name: Build embed_code.go for Windows
+        if: matrix.os == 'windows-latest'
+        run: go build -o ./bin/embed-code-win.exe -trimpath ./main.go
+
+      - name: Build embed_code.go for Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: go build -o ./bin/embed-code-ubuntu -trimpath ./main.go
+
+      - name: Build embed_code.go for MacOS
+        if: matrix.os == 'macos-latest'
+        env:
+          GOOS: darwin
+          GOARCH: amd64
+        run: go build -o ./bin/embed-code-macos -trimpath ./main.go
+
+      - name: Commit Built Files
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: './bin'
+          message: 'Build embed_code.go for ${{ matrix.os }}'
+          default_author: github_actions
+          push: true

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -11,12 +11,8 @@ jobs:
   build:
     # Prevents the workflow from running on non-human triggers.
     if: github.actor != 'github-actions[bot]'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      max-parallel: 1
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout Repository
@@ -28,24 +24,18 @@ jobs:
           go-version: '1.22.1'
 
       - name: Build embed_code.go for Windows
-        if: matrix.os == 'windows-latest'
-        run: go build -o ./bin/embed-code-win.exe -trimpath ./main.go
+        run: GOOS=windows GOARCH=amd64 go build -trimpath -o bin/embed-code-windows.exe main.go
 
       - name: Build embed_code.go for Ubuntu
-        if: matrix.os == 'ubuntu-latest'
-        run: go build -o ./bin/embed-code-ubuntu -trimpath ./main.go
+        run: GOOS=linux GOARCH=amd64 go build -trimpath -o bin/embed-code-linux main.go
 
       - name: Build embed_code.go for MacOS
-        if: matrix.os == 'macos-latest'
-        env:
-          GOOS: darwin
-          GOARCH: amd64
-        run: go build -o ./bin/embed-code-macos -trimpath ./main.go
+        run: GOOS=darwin GOARCH=amd64 go build -trimpath -o bin/embed-code-macos main.go
 
       - name: Commit Built Files
         uses: EndBug/add-and-commit@v9
         with:
           add: './bin'
-          message: 'Add binary for ${{ matrix.os }}.'
+          message: 'Update binaries.'
           default_author: github_actions
           push: true

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -1,6 +1,8 @@
 name: Build and Commit Binaries
 
-on: push
+on:
+  push:
+    branches: [master]
 
 concurrency:
   group: building

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Run Tests
 on:
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    # Prevents the workflow from running on non-human triggers.
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Up Go Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.1'
+
+      - name: Run Tests
+        # Tests must be run sequentially because they create temporary files that can cause issues.
+        # Therefore, the "-p 1" argument is required.
+        run: go test -v ./... -p 1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,9 +1,6 @@
 name: Run Tests
 
-on:
-  pull_request:
-    branches:
-      - master
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds:  
- tests that run on pull requests;  
- binaries that are built on pushes to the `master` branch.

Resolves https://github.com/SpineEventEngine/embed-code-go/issues/11.