### PR TITLE
Improve the display of missing files

### DIFF
--- a/fragmentation/fragment_file.go
+++ b/fragmentation/fragment_file.go
@@ -158,7 +158,10 @@ func (f FragmentFile) absolutePath() string {
 // code root and the resolved file does not exist, returns both the prefixed path and the expanded
 // absolute path.
 func (f FragmentFile) codeFileReference() (string, error) {
-	originalCodePath, isPrefixed := f.originalCodePath()
+	originalCodePath, isPrefixed, err := f.originalCodePath()
+	if err != nil {
+		return "", err
+	}
 	if originalCodePath == "" {
 		return fmt.Sprintf("%s", f.CodePath), nil
 	}
@@ -181,7 +184,9 @@ func (f FragmentFile) codeFileReference() (string, error) {
 //
 // Returns the absolute path to the source file and reports whether the input path used a named
 // code-root prefix such as `$runtime/...`.
-func (f FragmentFile) originalCodePath() (string, bool) {
+//
+// Returns an error if the path uses a named code root that is not present in the configuration.
+func (f FragmentFile) originalCodePath() (string, bool, error) {
 	normalizedPath := filepath.ToSlash(filepath.Clean(f.CodePath))
 
 	if strings.HasPrefix(normalizedPath, NamedPathPrefix) {
@@ -198,8 +203,11 @@ func (f FragmentFile) originalCodePath() (string, bool) {
 				panic(err)
 			}
 
-			return filepath.Join(absoluteRoot, filepath.FromSlash(relativePath)), true
+			return filepath.Join(absoluteRoot, filepath.FromSlash(relativePath)), true, nil
 		}
+
+		return "", true, fmt.Errorf("code root with name `%s` not found for path `%s`",
+			codeRootName, f.CodePath)
 	}
 
 	if len(f.Configuration.CodeRoots) == 1 {
@@ -208,10 +216,10 @@ func (f FragmentFile) originalCodePath() (string, bool) {
 			panic(err)
 		}
 
-		return filepath.Join(absoluteRoot, filepath.FromSlash(normalizedPath)), false
+		return filepath.Join(absoluteRoot, filepath.FromSlash(normalizedPath)), false, nil
 	}
 
-	return "", false
+	return "", false, nil
 }
 
 // Calculates and returns a hash string for FragmentFile.

--- a/fragmentation/fragment_file.go
+++ b/fragmentation/fragment_file.go
@@ -107,17 +107,22 @@ func (f FragmentFile) Content() ([]string, error) {
 	}
 
 	if !isPathFileExits {
+		codeFileReference, err := f.codeFileReference()
+		if err != nil {
+			return nil, err
+		}
+
 		if f.FragmentName != "" {
 			if f.FragmentName == "_default" {
-				return nil, fmt.Errorf("code file `%s` not found", f.CodePath)
+				return nil, fmt.Errorf("code file `%s` not found", codeFileReference)
 			}
 			return nil, fmt.Errorf(
-				"fragment `%s` from code file `%s` not found", f.FragmentName, f.CodePath,
+				"fragment `%s` from code file `%s` not found", f.FragmentName, codeFileReference,
 			)
 		}
 		return nil, fmt.Errorf(
-			"code file `%s` fragment not found",
-			f.CodePath,
+			"code file %s fragment not found",
+			codeFileReference,
 		)
 	}
 
@@ -145,6 +150,68 @@ func (f FragmentFile) absolutePath() string {
 	filename := fmt.Sprintf("%s-%s", withoutExtension, f.fragmentHash())
 
 	return filepath.Join(fragmentsAbsDir, filename+fileExtension)
+}
+
+// Builds a user-facing reference to the original code file for error messages.
+//
+// If the source file exists, returns its absolute `file://` URL. If the file path uses a named
+// code root and the resolved file does not exist, returns both the prefixed path and the expanded
+// absolute path.
+func (f FragmentFile) codeFileReference() (string, error) {
+	originalCodePath, isPrefixed := f.originalCodePath()
+	if originalCodePath == "" {
+		return fmt.Sprintf("%s", f.CodePath), nil
+	}
+
+	exists, err := files.IsFileExist(originalCodePath)
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return "file://" + originalCodePath, nil
+	}
+	if isPrefixed {
+		return fmt.Sprintf("%s (%s)", f.CodePath, originalCodePath), nil
+	}
+
+	return fmt.Sprintf("%s", originalCodePath), nil
+}
+
+// Resolves the original source file path from the fragment's code path.
+//
+// Returns the absolute path to the source file and reports whether the input path used a named
+// code-root prefix such as `$runtime/...`.
+func (f FragmentFile) originalCodePath() (string, bool) {
+	normalizedPath := filepath.ToSlash(filepath.Clean(f.CodePath))
+
+	if strings.HasPrefix(normalizedPath, NamedPathPrefix) {
+		withoutPrefix := strings.TrimPrefix(normalizedPath, NamedPathPrefix)
+		codeRootName, relativePath, _ := strings.Cut(withoutPrefix, "/")
+
+		for _, codeRoot := range f.Configuration.CodeRoots {
+			if strings.TrimSpace(codeRoot.Name) != codeRootName {
+				continue
+			}
+
+			absoluteRoot, err := filepath.Abs(codeRoot.Path)
+			if err != nil {
+				panic(err)
+			}
+
+			return filepath.Join(absoluteRoot, filepath.FromSlash(relativePath)), true
+		}
+	}
+
+	if len(f.Configuration.CodeRoots) == 1 {
+		absoluteRoot, err := filepath.Abs(f.Configuration.CodeRoots[0].Path)
+		if err != nil {
+			panic(err)
+		}
+
+		return filepath.Join(absoluteRoot, filepath.FromSlash(normalizedPath)), false
+	}
+
+	return "", false
 }
 
 // Calculates and returns a hash string for FragmentFile.

--- a/fragmentation/fragment_file.go
+++ b/fragmentation/fragment_file.go
@@ -163,7 +163,7 @@ func (f FragmentFile) codeFileReference() (string, error) {
 		return "", err
 	}
 	if originalCodePath == "" {
-		return fmt.Sprintf("%s", f.CodePath), nil
+		return f.CodePath, nil
 	}
 
 	exists, err := files.IsFileExist(originalCodePath)
@@ -177,7 +177,7 @@ func (f FragmentFile) codeFileReference() (string, error) {
 		return fmt.Sprintf("%s (%s)", f.CodePath, originalCodePath), nil
 	}
 
-	return fmt.Sprintf("%s", originalCodePath), nil
+	return originalCodePath, nil
 }
 
 // Resolves the original source file path from the fragment's code path.
@@ -198,12 +198,8 @@ func (f FragmentFile) originalCodePath() (string, bool, error) {
 				continue
 			}
 
-			absoluteRoot, err := filepath.Abs(codeRoot.Path)
-			if err != nil {
-				panic(err)
-			}
-
-			return filepath.Join(absoluteRoot, filepath.FromSlash(relativePath)), true, nil
+			return filepath.Join(resolvedRootPath(codeRoot.Path), filepath.FromSlash(relativePath)),
+				true, nil
 		}
 
 		return "", true, fmt.Errorf("code root with name `%s` not found for path `%s`",
@@ -211,15 +207,25 @@ func (f FragmentFile) originalCodePath() (string, bool, error) {
 	}
 
 	if len(f.Configuration.CodeRoots) == 1 {
-		absoluteRoot, err := filepath.Abs(f.Configuration.CodeRoots[0].Path)
-		if err != nil {
-			panic(err)
-		}
-
-		return filepath.Join(absoluteRoot, filepath.FromSlash(normalizedPath)), false, nil
+		return filepath.Join(
+			resolvedRootPath(f.Configuration.CodeRoots[0].Path),
+			filepath.FromSlash(normalizedPath),
+		), false, nil
 	}
 
 	return "", false, nil
+}
+
+// Resolves the given path to an absolute path when possible.
+//
+// If absolute-path resolution fails, returns the original path.
+func resolvedRootPath(path string) string {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+
+	return absolutePath
 }
 
 // Calculates and returns a hash string for FragmentFile.


### PR DESCRIPTION
This PR improves displaying of paths, when file or fragment wasn't found.
Resolves [this issue](https://github.com/SpineEventEngine/embed-code-go/issues/12).

Possible errors:
- When named path wasn't found:
```
Panic: failed to embed code fragment into doc file `file:///Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/target/target.md:2`: code root with name `first1` not found for path `$first1/hello/Hello.kt`
```
- When source file was found, but fragment wasn't:
```
Panic: failed to embed code fragment into doc file `file:///Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/target/target.md:2`: fragment `main1` from code file `file:///Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/source/hello/Hello.kt` not found
```
- When source file was not found, by named path:
```
Panic: failed to embed code fragment into doc file `file:///Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/target/target.md:2`: fragment `main` from code file `$first/hello/Hello2.kt (/Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/source/hello/Hello2.kt)` not found
```

- When file was not found, by unnamed path:
```
Panic: failed to embed code fragment into doc file `file:///Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/target/target.md:2`: fragment `main` from code file `/Users/vladyslav.kuksiuk/Desktop/Work/embed-code-go/my-test/source/hello/Hello2.kt` not found
```
