### PR TITLE
Provide execution permissions for binaries

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -2,7 +2,7 @@ name: Build and Commit Binaries
 
 on:
   push:
-#    branches: [ master ]
+    branches: [ master ]
     paths-ignore: # Prevents the workflow from running on binaries changes.
       - 'bin/**'
 
@@ -54,10 +54,10 @@ jobs:
           GOOS=darwin GOARCH=amd64 go build -trimpath -o bin/embed-code-macos main.go
           && chmod +x bin/embed-code-macos
 
-#      - name: Commit Built Files
-#        uses: EndBug/add-and-commit@v9
-#        with:
-#          add: './bin'
-#          message: 'Update binaries.'
-#          default_author: github_actions
-#          push: true
+      - name: Commit Built Files
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: './bin'
+          message: 'Update binaries.'
+          default_author: github_actions
+          push: true

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -2,7 +2,7 @@ name: Build and Commit Binaries
 
 on:
   push:
-    branches: [ master ]
+#    branches: [ master ]
     paths-ignore: # Prevents the workflow from running on binaries changes.
       - 'bin/**'
 
@@ -45,15 +45,19 @@ jobs:
         run: GOOS=windows GOARCH=amd64 go build -trimpath -o bin/embed-code-windows.exe main.go
 
       - name: Build embed_code.go for Ubuntu
-        run: GOOS=linux GOARCH=amd64 go build -trimpath -o bin/embed-code-linux main.go
+        run: >
+          GOOS=linux GOARCH=amd64 go build -trimpath -o bin/embed-code-linux main.go
+          && chmod +x bin/embed-code-linux
 
       - name: Build embed_code.go for MacOS
-        run: GOOS=darwin GOARCH=amd64 go build -trimpath -o bin/embed-code-macos main.go
+        run: >
+          GOOS=darwin GOARCH=amd64 go build -trimpath -o bin/embed-code-macos main.go
+          && chmod +x bin/embed-code-macos
 
-      - name: Commit Built Files
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: './bin'
-          message: 'Update binaries.'
-          default_author: github_actions
-          push: true
+#      - name: Commit Built Files
+#        uses: EndBug/add-and-commit@v9
+#        with:
+#          add: './bin'
+#          message: 'Update binaries.'
+#          default_author: github_actions
+#          push: true

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ based on the system where the binary was built.
 Run following command to build binaries for macOS, Windows and Ubuntu:
 ```bash
 mkdir -p bin && \
-GOOS=darwin GOARCH=amd64 go build -trimpath -o bin/embed-code-macos main.go && \
+GOOS=darwin GOARCH=amd64 go build -trimpath -o bin/embed-code-macos main.go && chmod +x bin/embed-code-macos && \
 GOOS=windows GOARCH=amd64 go build -trimpath -o bin/embed-code-windows.exe main.go && \
-GOOS=linux GOARCH=amd64 go build -trimpath -o bin/embed-code-linux main.go
+GOOS=linux GOARCH=amd64 go build -trimpath -o bin/embed-code-linux main.go && chmod +x bin/embed-code-linux
 ```
 
 ## Development Notes


### PR DESCRIPTION
This PR updates the `build_binaries` GH Workflow to provide execution permissions for the Linux and macOS binaries.