### PR TITLE
Prevent `CutIndent` from panicking on short blank lines

### DIFF
--- a/indent/indent.go
+++ b/indent/indent.go
@@ -56,13 +56,16 @@ func MaxCommonIndentation(lines []string) int {
 //
 // redundantSpaces — the number of leading spaces to remove from each line.
 //
+// If a line is shorter than redundantSpaces, the whole line is removed.
+//
 // Returns processed lines.
 func CutIndent(lines []string, redundantSpaces int) []string {
 	linesChanged := make([]string, len(lines))
 	copy(linesChanged, lines)
 	for i, line := range linesChanged {
 		if len(line) > 0 {
-			linesChanged[i] = line[redundantSpaces:]
+			cutLength := min(redundantSpaces, len(line))
+			linesChanged[i] = line[cutLength:]
 		}
 	}
 

--- a/indent/indent_test.go
+++ b/indent/indent_test.go
@@ -61,7 +61,11 @@ var _ = Describe("Indent", func() {
 	})
 
 	It("should cut lines shorter than the indentation", func() {
-		testLines := []string{"        System.out.println(\"Hi\");", "  ", "        return;"}
+		testLines := []string{
+			"        System.out.println(\"Hi\");",
+			"  ",
+			"        return;",
+		}
 
 		changedLines := indent.CutIndent(testLines, 8)
 

--- a/indent/indent_test.go
+++ b/indent/indent_test.go
@@ -60,4 +60,16 @@ var _ = Describe("Indent", func() {
 		Expect(changedLines).ShouldNot(Equal(testLines))
 	})
 
+	It("should cut lines shorter than the indentation", func() {
+		testLines := []string{"        System.out.println(\"Hi\");", "  ", "        return;"}
+
+		changedLines := indent.CutIndent(testLines, 8)
+
+		Expect(changedLines).Should(Equal([]string{
+			"System.out.println(\"Hi\");",
+			"",
+			"return;",
+		}))
+	})
+
 })


### PR DESCRIPTION
Fixes a panic in `CutIndent` when a whitespace-only line is shorter than the common indentation. The removal is now clamped to the line length.

Resolves [this issue](https://github.com/SpineEventEngine/embed-code-go/issues/57).