### PR TITLE
Add focused parser state-transition tests

### DIFF
--- a/embedding/parsing/state_test.go
+++ b/embedding/parsing/state_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package parsing_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"embed-code/embed-code-go/configuration"
+	"embed-code/embed-code-go/embedding/parsing"
+	_type "embed-code/embed-code-go/type"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Parser states", func() {
+	It("should consume a multiline instruction before opening an embedding fence", func() {
+		config := configuration.NewConfiguration()
+		context := newStateContext(
+			"<embed-code",
+			"    file=\"Example.java\"/>",
+			"    ````java",
+			"old source",
+			"    ````",
+		)
+
+		Expect(parsing.EmbedInstruction.Recognize(context)).Should(BeTrue())
+		Expect(parsing.EmbedInstruction.Accept(&context, config)).Should(Succeed())
+
+		Expect(context.CurrentIndex()).Should(Equal(3))
+		Expect(context.EmbeddingInstruction).ShouldNot(BeNil())
+		Expect(context.EmbeddingInstruction.CodeFile).Should(Equal("Example.java"))
+		Expect(context.EmbeddingInstruction.DocumentationLine).Should(Equal(1))
+		Expect(context.GetResult()).Should(Equal([]string{
+			"<embed-code",
+			"    file=\"Example.java\"/>",
+		}))
+
+		Expect(parsing.CodeFenceStart.Recognize(context)).Should(BeTrue())
+		Expect(parsing.CodeFenceStart.Accept(&context, config)).Should(Succeed())
+
+		Expect(context.CurrentIndex()).Should(Equal(4))
+		Expect(context.CodeFenceStarted).Should(BeTrue())
+		Expect(context.CodeFenceMarker).Should(Equal("````"))
+		Expect(context.CodeFenceIndentation).Should(Equal(4))
+		Expect(context.CurrentEmbedding().SourceStartIndex).Should(Equal(3))
+	})
+
+	It("should recognize only matching embedding fence endings", func() {
+		context := newStateContext(
+			"    ```",
+			"```",
+			"    ````",
+			"    ``` language",
+		)
+		context.CodeFenceStarted = true
+		context.CodeFenceMarker = "```"
+		context.CodeFenceIndentation = 4
+
+		Expect(parsing.CodeFenceEnd.Recognize(context)).Should(BeTrue())
+
+		context.ToNextLine()
+		Expect(parsing.CodeFenceEnd.Recognize(context)).Should(BeFalse())
+
+		context.ToNextLine()
+		Expect(parsing.CodeFenceEnd.Recognize(context)).Should(BeTrue())
+
+		context.ToNextLine()
+		Expect(parsing.CodeFenceEnd.Recognize(context)).Should(BeFalse())
+	})
+
+	It("should report a malformed instruction when EOF is reached before the tag closes", func() {
+		config := configuration.NewConfiguration()
+		context := newStateContext(
+			"preface",
+			"<embed-code",
+			"    file=\"Example.java\"",
+		)
+		Expect(parsing.RegularLine.Accept(&context, config)).Should(Succeed())
+
+		err := parsing.EmbedInstruction.Accept(&context, config)
+
+		Expect(err).Should(HaveOccurred())
+		var parseErr parsing.InstructionParseError
+		Expect(errors.As(err, &parseErr)).Should(BeTrue())
+		Expect(parseErr.Line).Should(Equal(2))
+		Expect(parseErr.Reason).Should(Equal("the `<embed-code>` tag is not closed"))
+		Expect(context.ReachedEOF()).Should(BeTrue())
+		Expect(context.GetResult()).Should(Equal([]string{
+			"preface",
+			"<embed-code",
+			"    file=\"Example.java\"",
+		}))
+	})
+
+	It("should render source and close the embedding fence when the end state is accepted", func() {
+		sourceRoot := GinkgoT().TempDir()
+		Expect(os.WriteFile(
+			filepath.Join(sourceRoot, "Example.java"),
+			[]byte("class Example {}\n"),
+			0600,
+		)).To(Succeed())
+		config := configuration.NewConfiguration()
+		config.CodeRoots = _type.NamedPathList{_type.NamedPath{Path: sourceRoot}}
+		context := newStateContext(
+			"<embed-code file=\"Example.java\"/>",
+			"```java",
+			"old source",
+			"```",
+		)
+		Expect(parsing.EmbedInstruction.Accept(&context, config)).Should(Succeed())
+		Expect(parsing.CodeFenceStart.Accept(&context, config)).Should(Succeed())
+		Expect(parsing.CodeSampleLine.Accept(&context, config)).Should(Succeed())
+
+		Expect(parsing.CodeFenceEnd.Recognize(context)).Should(BeTrue())
+		Expect(parsing.CodeFenceEnd.Accept(&context, config)).Should(Succeed())
+
+		Expect(context.CodeFenceStarted).Should(BeFalse())
+		Expect(context.EmbeddingInstruction).Should(BeNil())
+		Expect(context.CurrentEmbedding().SourceEndIndex).Should(Equal(3))
+		Expect(context.GetResult()).Should(Equal([]string{
+			"<embed-code file=\"Example.java\"/>",
+			"```java",
+			"class Example {}",
+			"```",
+		}))
+	})
+})
+
+// newStateContext builds a parser context from in-memory source lines.
+func newStateContext(lines ...string) parsing.Context {
+	docPath := filepath.Join(GinkgoT().TempDir(), "doc.md")
+	err := os.WriteFile(docPath, []byte(strings.Join(lines, "\n")), 0600)
+	if err != nil {
+		Fail("unexpected error while writing parser state fixture: " + err.Error())
+	}
+	context, err := parsing.NewContext(docPath)
+	if err != nil {
+		Fail("unexpected error while creating parser state context: " + err.Error())
+	}
+
+	return context
+}


### PR DESCRIPTION
This PR adds own-package tests for parser states in `embedding/parsing`.

Resolves [this issue](https://github.com/SpineEventEngine/embed-code-go/issues/63).