### PR TITLE
Provide test coverage 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         run: go test ./... -covermode=atomic -coverpkg=./... -coverprofile=cover.out
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./cover.out
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,35 @@
+name: Coverage
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set Up Go Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Generate Test Coverage
+        run: go test ./... -covermode=atomic -coverpkg=./... -coverprofile=cover.out
+
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./cover.out
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,9 @@ name: Coverage
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -57,6 +57,8 @@ This repository is configured with these GitHub workflows:
 
 - `check`: runs linting, the normal Go test suite, and the showcase end-to-end
   tests across supported platforms.
+- `coverage`: uploads Go coverage to Codecov, where `codecov.yml` requires
+  90% patch coverage for pull requests.
 - `release-binaries`: reads `VERSION`, builds Linux, macOS, and Windows
   binaries, signs and notarizes the macOS ARM64 and x64 ZIPs, and creates the
   matching GitHub Release on pushes to `master`. It runs on a self-hosted macOS

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -58,7 +58,9 @@ This repository is configured with these GitHub workflows:
 - `check`: runs linting, the normal Go test suite, and the showcase end-to-end
   tests across supported platforms.
 - `coverage`: uploads Go coverage to Codecov, where `codecov.yml` requires
-  90% patch coverage for pull requests.
+  90% patch coverage for pull requests. The workflow also runs on pushes to
+  `master` to populate base coverage for later pull-request diffs and the
+  README badge; `master` pushes do not have a coverage status gate by design.
 - `release-binaries`: reads `VERSION`, builds Linux, macOS, and Windows
   binaries, signs and notarizes the macOS ARM64 and x64 ZIPs, and creates the
   matching GitHub Release on pushes to `master`. It runs on a self-hosted macOS

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Embed Code
 
+[![Coverage](https://codecov.io/gh/SpineEventEngine/embed-code-go/branch/master/graph/badge.svg)](https://codecov.io/gh/SpineEventEngine/embed-code-go)
+
 Embed Code is a Go command-line tool that keeps documentation snippets in sync
 with source files. It scans Markdown and HTML documents for `<embed-code>`
 instructions, resolves the requested source content, and manages the following

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project: off
+    patch:
+      default:
+        target: 90%
+        threshold: 0%
+        only_pulls: true


### PR DESCRIPTION
This PR provides test coverage verification via Codecov.

Resolves [this issue](https://github.com/SpineEventEngine/embed-code-go/issues/106).